### PR TITLE
Added YAML and XML export formats (territories, histories, and provinces)

### DIFF
--- a/opengs_maptool/logic/export_module.py
+++ b/opengs_maptool/logic/export_module.py
@@ -1,6 +1,9 @@
 import json
 from PyQt6.QtWidgets import QFileDialog
 import csv
+import yaml
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
 
 
 def export_image(parent_layout, image, text):
@@ -28,15 +31,37 @@ def export_territory_definitions(main_layout):
     if not path:
         return
 
-    if fmt == "json":
+    if fmt in ("json", "yaml", "xml"):
         data = {}
         for d in territory_data:
             data[d["territory_id"]] = {
                 "territory_type": d["territory_type"],
                 "R": d["R"], "G": d["G"], "B": d["B"],
-                "x": round(d["x"], 2), "y": round(d["y"], 2),
+                "x": round(float(d["x"]), 2),
+                "y": round(float(d["y"]), 2),
             }
-        _write_json(path, data)
+
+        if fmt == "json":
+            _write_json(path, data)
+        elif fmt == "yaml":
+            _write_yaml(path, data)
+        elif fmt == "xml":
+            root = ET.Element("territories")
+
+            for territory_id, info in data.items():
+                territory_element = ET.SubElement(root, "territory")
+                territory_element.set("id", str(territory_id))
+                
+                for key, value in info.items():
+                    element = ET.SubElement(territory_element, key)
+                    element.text = str(value)
+
+            rough_xml = ET.tostring(root, encoding="unicode")
+            pretty_xml = minidom.parseString(rough_xml).toprettyxml(indent="    ")
+            
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(pretty_xml)
+
     else:
         with open(path, "w", newline="", encoding="utf-8") as f:
             w = csv.writer(f, delimiter=';')
@@ -57,13 +82,35 @@ def export_territory_history(main_layout):
     if not path:
         return
 
-    if fmt == "json":
+    if fmt in ("json", "yaml", "xml"):
         data = {}
         for d in territory_data:
             data[d["territory_id"]] = {
                 "provinces": d.get("province_ids", []),
             }
-        _write_json(path, data)
+        if fmt == "json":
+            _write_json(path, data)
+        elif fmt == "yaml":
+            _write_yaml(path, data)
+        elif fmt == "xml":
+            root = ET.Element("territories")
+
+            for territory_id, info in data.items():
+                territory_element = ET.SubElement(root, "territory")
+                territory_element.set("id", str(territory_id))
+                
+                provinces_element = ET.SubElement(territory_element, "provinces")
+
+                for province_id in info.get("provinces", []):
+                    province_element = ET.SubElement(provinces_element, "province")
+                    province_element.text = str(province_id)
+
+            rough_xml = ET.tostring(root, encoding="unicode")
+            pretty_xml = minidom.parseString(rough_xml).toprettyxml(indent="    ")
+            
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(pretty_xml)
+
     else:
         with open(path, "w", newline="", encoding="utf-8") as f:
             w = csv.writer(f, delimiter=';')
@@ -85,18 +132,39 @@ def export_province_definitions(main_layout):
 
     has_terrain = any("province_terrain" in d for d in province_data)
 
-    if fmt == "json":
+    if fmt in ("json", "yaml", "xml"):
         data = {}
         for d in province_data:
             entry = {
                 "province_type": d["province_type"],
                 "R": d["R"], "G": d["G"], "B": d["B"],
-                "x": round(d["x"], 2), "y": round(d["y"], 2),
+                "x": round(float(d["x"]), 2),
+                "y": round(float(d["y"]), 2),
             }
             if has_terrain:
                 entry["province_terrain"] = d.get("province_terrain", "unknown")
             data[d["province_id"]] = entry
-        _write_json(path, data)
+        if fmt == "json":
+            _write_json(path, data)
+        elif fmt == "yaml":
+            _write_yaml(path, data)
+        elif fmt == "xml":
+            root = ET.Element("provinces")
+
+            for province_id, info in data.items():
+                province_element = ET.SubElement(root, "province")
+                province_element.set("id", str(province_id))
+
+                for key, value in info.items():
+                    element = ET.SubElement(province_element, key)
+                    element.text = str(value)
+
+            rough_xml = ET.tostring(root, encoding="unicode")
+            pretty_xml = minidom.parseString(rough_xml).toprettyxml(indent="    ")
+
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(pretty_xml)
+
     else:
         with open(path, "w", newline="", encoding="utf-8") as f:
             w = csv.writer(f, delimiter=';')
@@ -113,11 +181,15 @@ def export_province_definitions(main_layout):
                 w.writerow(row)
 
 
-
 def _pick_file(parent, title):
-    """Open save dialog with JSON/CSV filter. Returns (path, format) or (None, None)."""
+    """Open save dialog with data format filters. Returns (path, format) or (None, None)."""
     path, selected_filter = QFileDialog.getSaveFileName(
-        parent, title, "", "JSON Files (*.json);;CSV Files (*.csv)")
+        parent, title, "", 
+        "JSON Files (*.json);;" \
+        "CSV Files (*.csv);;" \
+        "YAML Files (*.yaml);;" \
+        "XML Files (*.xml)"
+    )
     if not path:
         return None, None
 
@@ -126,9 +198,19 @@ def _pick_file(parent, title):
         fmt = "json"
     elif path.lower().endswith(".csv"):
         fmt = "csv"
+    elif path.lower().endswith(".yaml"):
+        fmt = "yaml"
+    elif path.lower().endswith(".xml"):
+        fmt = "xml"
     elif "json" in selected_filter.lower():
         fmt = "json"
         path += ".json"
+    elif "yaml" in selected_filter.lower():
+        fmt = "yaml"
+        path += ".yaml"
+    elif "xml" in selected_filter.lower():
+        fmt = "xml"
+        path += ".xml"
     else:
         fmt = "csv"
         path += ".csv"
@@ -139,3 +221,8 @@ def _pick_file(parent, title):
 def _write_json(path, data):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4)
+
+
+def _write_yaml(path, data):
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.dump(data, f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyQt6_sip==13.10.2",
     "scipy==1.16.3",
     "tkinterdnd2==0.4.3",
+    "PyYAML==6.0.3"
 ]
 
 classifiers = [


### PR DESCRIPTION
I've added the ability to export to two other widely used formats: **YAML** and **XML**.
YAML is commonly used for web development, and XML is natively supported by Java, for example.

This addition applies to territories (including their histories) and provinces.

The data format remains consistent with the one already created for JSON.

I only modified the `export_module.py` file and added a module (*PyYAML/) to `pyproject.toml`.

I've tested each export locally, and everything works as expected.



Example of the format for a territories export file in XML:
<img width="422" height="346" alt="{CC98C983-43A9-48C8-A5D3-110A98DC7780}" src="https://github.com/user-attachments/assets/ec1340d6-3523-4293-bcfd-faad0e78be19" />

The same thing, but in YAML:
<img width="252" height="271" alt="{E1CD7EF0-CC10-47D8-8F70-F76AE48527DC}" src="https://github.com/user-attachments/assets/82a4b848-f906-4e5a-9a97-95e20bb15f04" />