### PR TITLE
Added support for multiple image export formats

### DIFF
--- a/opengs_maptool/logic/export_module.py
+++ b/opengs_maptool/logic/export_module.py
@@ -1,5 +1,6 @@
-import json
 from PyQt6.QtWidgets import QFileDialog
+from PIL import Image
+import json
 import csv
 import yaml
 import xml.etree.ElementTree as ET
@@ -9,12 +10,17 @@ from xml.dom import minidom
 def export_image(parent_layout, image, text):
     if image:
         try:
-            path, _ = QFileDialog.getSaveFileName(
-                parent_layout, text, "", "PNG Files (*.png)")
+            path = _pick_file_image(parent_layout, text)
             if not path:
                 return
-            if not path.lower().endswith(".png"):
-                path += ".png"
+            
+            # Remove the alpha channel for JPEG image export
+            ext = path.lower().rsplit('.', 1)[-1]
+            if ext in ("jpg", "jpeg"):
+                background = Image.new('RGB', image.size, (255, 255, 255))
+                background.paste(image, mask=image.split()[3])
+                image = background
+
             image.save(path)
 
         except Exception as error:
@@ -27,7 +33,7 @@ def export_territory_definitions(main_layout):
         print("No territory data to export.")
         return
 
-    path, fmt = _pick_file(main_layout, "Export Territory Definitions")
+    path, fmt = _pick_file_data(main_layout, "Export Territory Definitions")
     if not path:
         return
 
@@ -78,7 +84,7 @@ def export_territory_history(main_layout):
         print("No territory data to export.")
         return
 
-    path, fmt = _pick_file(main_layout, "Export Territory History")
+    path, fmt = _pick_file_data(main_layout, "Export Territory History")
     if not path:
         return
 
@@ -126,7 +132,7 @@ def export_province_definitions(main_layout):
         print("No province data to export.")
         return
 
-    path, fmt = _pick_file(main_layout, "Export Province Definitions")
+    path, fmt = _pick_file_data(main_layout, "Export Province Definitions")
     if not path:
         return
 
@@ -181,15 +187,51 @@ def export_province_definitions(main_layout):
                 w.writerow(row)
 
 
-def _pick_file(parent, title):
+def _pick_file_image(parent, title):
+    """Open save dialog with image format filters. Returns path (with valid file extension) or None"""
+    filters = (
+        "PNG Files (*.png);;" \
+        "JPEG Files (*.jpg *.jpeg);;" \
+        "BMP Files (*.bmp);;" \
+        "GIF Files (*.gif);;"
+        "TIFF Files (*.tiff *.tif);;"
+        "WebP Files (*.webp);;" \
+        "All Files (*.*)"
+    )
+    
+    path, selected_filter = QFileDialog.getSaveFileName(parent, title, "", filters)
+    if not path:
+        return None
+    
+    if not path.lower().endswith((".png", ".jpg", ".jpeg", ".bmp", ".gif", ".tiff", ".tif", ".webp")):
+        if "png" in selected_filter.lower():
+            path += ".png"
+        elif "jpeg" in selected_filter.lower(): # or .jpg
+            path += ".jpg"
+        elif "bmp" in selected_filter.lower():
+            path += ".bmp"
+        elif "gif" in selected_filter.lower():
+            path += ".gif"
+        elif "tiff" in selected_filter.lower(): # or .tif
+            path += ".tiff"
+        elif "webp" in selected_filter.lower():
+            path += ".webp"
+        else: # default format
+            path += ".png"
+
+    return path
+
+
+def _pick_file_data(parent, title):
     """Open save dialog with data format filters. Returns (path, format) or (None, None)."""
-    path, selected_filter = QFileDialog.getSaveFileName(
-        parent, title, "", 
+    filters = (
         "JSON Files (*.json);;" \
         "CSV Files (*.csv);;" \
         "YAML Files (*.yaml);;" \
         "XML Files (*.xml)"
     )
+    
+    path, selected_filter = QFileDialog.getSaveFileName(parent, title, "", filters)
     if not path:
         return None, None
 

--- a/opengs_maptool/logic/export_module.py
+++ b/opengs_maptool/logic/export_module.py
@@ -190,7 +190,7 @@ def export_province_definitions(main_layout):
 def _pick_file_image(parent, title):
     """Open save dialog with image format filters. Returns path (with valid file extension) or None"""
     filters = (
-        "All Files (*.*);;"
+        "All Files (*);;"
         "PNG Files (*.png);;"
         "JPEG Files (*.jpg *.jpeg);;"
         "BMP Files (*.bmp);;"
@@ -225,7 +225,7 @@ def _pick_file_image(parent, title):
 def _pick_file_data(parent, title):
     """Open save dialog with data format filters. Returns (path, format) or (None, None)."""
     filters = (
-        "All Files (*.*);;"
+        "All Files (*);;"
         "JSON Files (*.json);;"
         "CSV Files (*.csv);;"
         "YAML Files (*.yaml *.yml);;"

--- a/opengs_maptool/logic/export_module.py
+++ b/opengs_maptool/logic/export_module.py
@@ -190,13 +190,13 @@ def export_province_definitions(main_layout):
 def _pick_file_image(parent, title):
     """Open save dialog with image format filters. Returns path (with valid file extension) or None"""
     filters = (
-        "PNG Files (*.png);;" \
-        "JPEG Files (*.jpg *.jpeg);;" \
-        "BMP Files (*.bmp);;" \
+        "All Files (*.*);;"
+        "PNG Files (*.png);;"
+        "JPEG Files (*.jpg *.jpeg);;"
+        "BMP Files (*.bmp);;"
         "GIF Files (*.gif);;"
         "TIFF Files (*.tiff *.tif);;"
-        "WebP Files (*.webp);;" \
-        "All Files (*.*)"
+        "WebP Files (*.webp)"
     )
     
     path, selected_filter = QFileDialog.getSaveFileName(parent, title, "", filters)
@@ -225,37 +225,44 @@ def _pick_file_image(parent, title):
 def _pick_file_data(parent, title):
     """Open save dialog with data format filters. Returns (path, format) or (None, None)."""
     filters = (
-        "JSON Files (*.json);;" \
-        "CSV Files (*.csv);;" \
-        "YAML Files (*.yaml);;" \
+        "All Files (*.*);;"
+        "JSON Files (*.json);;"
+        "CSV Files (*.csv);;"
+        "YAML Files (*.yaml *.yml);;"
         "XML Files (*.xml)"
     )
     
     path, selected_filter = QFileDialog.getSaveFileName(parent, title, "", filters)
     if not path:
         return None, None
-
-    # Determine format from extension, fall back to selected filter
+        
+    # Determine format from extension
     if path.lower().endswith(".json"):
         fmt = "json"
     elif path.lower().endswith(".csv"):
         fmt = "csv"
-    elif path.lower().endswith(".yaml"):
+    elif path.lower().endswith((".yaml", ".yml")):
         fmt = "yaml"
     elif path.lower().endswith(".xml"):
         fmt = "xml"
-    elif "json" in selected_filter.lower():
-        fmt = "json"
-        path += ".json"
-    elif "yaml" in selected_filter.lower():
-        fmt = "yaml"
-        path += ".yaml"
-    elif "xml" in selected_filter.lower():
-        fmt = "xml"
-        path += ".xml"
-    else:
-        fmt = "csv"
-        path += ".csv"
+    
+    # Fallback to the selected filter
+    elif not path.lower().endswith((".json", ".csv", ".yaml", ".yml", ".xml")):
+        if "json" in selected_filter.lower():
+            fmt = "json"
+            path += ".json"
+        elif "yaml" in selected_filter.lower(): # or .yml
+            fmt = "yaml"
+            path += ".yaml"
+        elif "xml" in selected_filter.lower():
+            fmt = "xml"
+            path += ".xml"
+        elif "csv" in selected_filter.lower():
+            fmt = "csv"
+            path += ".csv"
+        else: # default format
+            fmt = "json"
+            path += ".json"
 
     return path, fmt
 


### PR DESCRIPTION
I've added the ability to export images in various formats, such as:
- JPEG
- BMP
- GIF
- TIFF
- WebP

I’ve also modified the *QFileDialog* to include an `All files (*)` filter so you can easily view the contents of a directory, a feature commonly found in many software programs.
Consequently, the **default format is now PNG for images and JSON for data** (no longer CSV, but if you prefer CSV, I can always revert it to the previous setting).

> Note: I haven’t applied any compression to the new image formats that support compression (such as JPEG). It might be worth adding that in the future. 

I’ve verified that the new features work correctly one by one: every exported image is in the correct format (thanks to PIL). Additionally, the data file export works as intended.