### PR TITLE
ci: drop the macOS Intel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,9 @@ jobs:
           - os: ubuntu-22.04
             label: Linux
             asset: OpenGS-MapTool-linux-x86_64.tar.gz
-          - os: macos-13
-            label: macOS (Intel)
-            asset: OpenGS-MapTool-macos-x86_64.zip
+          # Apple Silicon only. The macos-13 Intel runners are being retired
+          # and jobs sent to them sit queued forever, which blocks the release.
+          # Intel Mac users can still run from source.
           - os: macos-14
             label: macOS (Apple Silicon)
             asset: OpenGS-MapTool-macos-arm64.zip

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Output Province Map:
 2. Download the file for your system
 3. Run the Executable
 
+The macOS build is for Apple Silicon. On an Intel Mac, use Option 2.
+
 These builds aren't code signed, so Windows and macOS will warn you the first time you open one.
 On Windows pick "More info" then "Run anyway", on macOS right-click the app and choose "Open".
 


### PR DESCRIPTION
- Jobs sent to macos-13 never get a runner and sit queued, blocking the release
- macOS builds are Apple Silicon only now; Intel Macs can run from source