### PR TITLE
ci: ship the example images alongside the executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         include:
           - os: windows-latest
             label: Windows
-            asset: OpenGS-MapTool-windows-x86_64.exe
+            asset: OpenGS-MapTool-windows-x86_64.zip
           - os: ubuntu-22.04
             label: Linux
             asset: OpenGS-MapTool-linux-x86_64.tar.gz
@@ -142,20 +142,40 @@ jobs:
           --exclude-module tkinter --exclude-module tkinterdnd2 --exclude-module pytest
           opengs_maptool/main.py
 
+      # Every platform ships a folder, not a bare executable, so the example
+      # input images travel with the app. They are what a new user needs to
+      # generate their first map.
+      - name: Stage release files
+        shell: bash
+        run: |
+          stage="staging/${{ env.APP_NAME }}"
+          mkdir -p "$stage"
+
+          case "${{ runner.os }}" in
+            Windows) cp "dist/${{ env.APP_NAME }}.exe" "$stage/" ;;
+            Linux)   cp "dist/${{ env.APP_NAME }}" "$stage/" ;;
+            # ditto rather than cp, to keep the .app bundle intact.
+            macOS)   ditto "dist/${{ env.APP_NAME }}.app" "$stage/${{ env.APP_NAME }}.app" ;;
+          esac
+
+          cp -R examples/input "$stage/examples"
+          cp README.md LICENSE "$stage/"
+          ls -laR "$stage" | head -30
+
       - name: Package (Windows)
         if: runner.os == 'Windows'
-        shell: bash
-        run: mv "dist/${{ env.APP_NAME }}.exe" "${{ matrix.asset }}"
+        shell: pwsh
+        run: Compress-Archive -Path "staging/${{ env.APP_NAME }}" -DestinationPath "${{ matrix.asset }}"
 
       - name: Package (Linux)
         if: runner.os == 'Linux'
         # tar keeps the executable bit, which a bare release download loses.
-        run: tar -czf "${{ matrix.asset }}" -C dist "${{ env.APP_NAME }}"
+        run: tar -czf "${{ matrix.asset }}" -C staging "${{ env.APP_NAME }}"
 
       - name: Package (macOS)
         if: runner.os == 'macOS'
         # ditto preserves the .app bundle structure that plain zip mangles.
-        run: ditto -c -k --sequesterRsrc --keepParent "dist/${{ env.APP_NAME }}.app" "${{ matrix.asset }}"
+        run: ditto -c -k --sequesterRsrc --keepParent "staging/${{ env.APP_NAME }}" "${{ matrix.asset }}"
 
       - name: Check the asset was produced
         shell: bash

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Output Province Map:
 ## How to install
 ### Option 1 (Windows, macOS or Linux):
 1. "Releases" section in Github
-2. Download the file for your system
+2. Download and unpack the file for your system
 3. Run the Executable
+
+The download includes the example input images in an `examples` folder, so you have something to generate a map from straight away.
 
 The macOS build is for Apple Silicon. On an Intel Mac, use Option 2.
 


### PR DESCRIPTION
- Package every platform as a folder instead of a bare executable
- Include the example input images, the README and the licence
- Windows now releases as a zip like the other platforms