### PR TITLE
feat: replace jagged border checkboxes with strength sliders

### DIFF
--- a/opengs_maptool/config.py
+++ b/opengs_maptool/config.py
@@ -45,7 +45,20 @@ MAX_IMAGE_PIXELS = 300000000
 
 # Generation algorithm
 LLOYD_ITERATIONS = 4
-JAGGED_BORDER_AMPLITUDE = 0.12  # fraction of avg seed spacing used as noise
+
+# Jagged Land Border Amplitud Factor
+JAGGED_BORDER_LAND_AMPLITUDE_DEFAULT = 12  # fraction of avg seed spacing used as noise.  Slider value (divided by 10 = 2.0)
+JAGGED_BORDER_LAND_AMPLITUDE_MIN = 0
+JAGGED_BORDER_LAND_AMPLITUDE_MAX  = 50
+JAGGED_BORDER_LAND_AMPLITUDE_TICK = 1
+JAGGED_BORDER_LAND_AMPLITUDE_STEP = 1
+
+# Jagged Ocean Border Amplitud Factor
+JAGGED_BORDER_OCEAN_AMPLITUDE_DEFAULT = 12  # fraction of avg seed spacing used as noise.  Slider value (divided by 10 = 2.0)
+JAGGED_BORDER_OCEAN_AMPLITUDE_MIN = 0
+JAGGED_BORDER_OCEAN_AMPLITUDE_MAX  = 50
+JAGGED_BORDER_OCEAN_AMPLITUDE_TICK = 1
+JAGGED_BORDER_OCEAN_AMPLITUDE_STEP = 1
 
 # Number Series
 PROVINCE_ID_PREFIX = "PRV"

--- a/opengs_maptool/logic/province_generator.py
+++ b/opengs_maptool/logic/province_generator.py
@@ -45,8 +45,8 @@ def generate_province_map(
         
         density_strength = project.province_density_strength / 10.0
         exclude_ocean_density = project.province_exclude_ocean
-        jagged_land = project.province_jagged_land
-        jagged_ocean = project.province_jagged_ocean
+        jagged_land_strength = project.province_jagged_land_amplitude / 100.0
+        jagged_ocean_strength = project.province_jagged_ocean_amplitude / 100.0
         map_h, map_w = masks.map_h, masks.map_w
 
         total_land_provs = project.land_province_density
@@ -185,7 +185,7 @@ def generate_province_map(
                 terr_density = density_arr
                 terr_density_strength = density_strength
 
-            jagged = jagged_land if region_type == ds.RegionType.LAND else jagged_ocean
+            amplitude_factor = jagged_land_strength if region_type == ds.RegionType.LAND else jagged_ocean_strength
 
             # Pass None for inner progress controller to create_region_map here
             # to keep granular updates balanced across territory iterations
@@ -193,8 +193,8 @@ def generate_province_map(
                 terr_fill, terr_border, prov_count, start_index,
                 series, region_type, ds.RegionLevel.PROVINCE,
                 ProgressController(), # ignore sub progress as we already track loop progress
-                density=terr_density, density_strength=terr_density_strength,
-                jagged=jagged
+                density=terr_density, density_strength=terr_density_strength, 
+                amplitude_factor=amplitude_factor
             )
 
             # Tag each province with its parent territory

--- a/opengs_maptool/logic/territory_generator.py
+++ b/opengs_maptool/logic/territory_generator.py
@@ -58,8 +58,8 @@ def generate_territory_map(
         density_arr: NDArray[Any] = np.array(project.density_image)
         density_strength = project.territory_density_strength / 10.0
         exclude_ocean_density = project.territory_exclude_ocean
-        jagged_land = project.territory_jagged_land
-        jagged_ocean = project.territory_jagged_ocean
+        land_amplitude_factor = project.territory_jagged_land_amplitude / 100.0
+        ocean_amplitude_factor = project.territory_jagged_ocean_amplitude / 100.0
 
         land_points = project.land_territory_density
         sea_points = project.oceanic_territory_density
@@ -72,7 +72,7 @@ def generate_territory_map(
             series, ds.RegionType.LAND, ds.RegionLevel.TERRITORY,
             sub_progress3,
             density=density_arr, density_strength=density_strength,
-            jagged=jagged_land,
+            amplitude_factor=land_amplitude_factor
         )
 
     with progress_controller.execute_phase(phase4) as sub_progress4:
@@ -85,8 +85,8 @@ def generate_territory_map(
                 masks.sea_fill, masks.sea_border, sea_points, next_index,
                 series, ds.RegionType.OCEAN, ds.RegionLevel.TERRITORY,
                 sub_progress4,
-                density=sea_density, density_strength=sea_density_strength,
-                jagged=jagged_ocean,
+                density=sea_density, density_strength=sea_density_strength, 
+                amplitude_factor=ocean_amplitude_factor
             )
         else:
             # Consume sub_progress4 (which surprisingly isn't nededed) to keep the progress bar moving

--- a/opengs_maptool/logic/utils.py
+++ b/opengs_maptool/logic/utils.py
@@ -136,7 +136,7 @@ def lloyd_relaxation(
     return point_seeds
 
 
-def _build_jitter_maps(h: int, w: int, seeds_arr: ds.JitterSeedsArray) -> tuple[ds.JitterSeedsArray, ds.JitterSeedsArray] | tuple[None, None]:
+def _build_jitter_maps(amplitude_factor, h: int, w: int, seeds_arr: ds.JitterSeedsArray) -> tuple[ds.JitterSeedsArray, ds.JitterSeedsArray] | tuple[None, None]:
     """Build spatially-correlated noise maps for jagged border effect.
 
     Returns (jitter_x, jitter_y) arrays of shape (h, w), or (None, None)
@@ -151,7 +151,7 @@ def _build_jitter_maps(h: int, w: int, seeds_arr: ds.JitterSeedsArray) -> tuple[
     seed_tree = cKDTree(seeds_arr)
     nn_dists, _ = seed_tree.query(seeds_arr, k=2)
     avg_dist = float(nn_dists[:, 1].mean())
-    amplitude = avg_dist * config.JAGGED_BORDER_AMPLITUDE
+    amplitude = avg_dist * amplitude_factor
 
     # Coarse noise grid — each cell covers ~avg_dist/4 pixels
     cell = max(4, int(avg_dist / 4))
@@ -208,7 +208,7 @@ def _remove_enclaves(pmap: ds.RegionPixelMap, mask: ds.BooleanMaskMap, progress_
 
 def assign_regions(
         mask: ds.BooleanMaskMap, seeds: list[ds.IntCoordinate], start_index: int,
-        progress_controller: ProgressController, jagged: bool = False
+        progress_controller: ProgressController, amplitude_factor=0.0
     ) -> ds.RegionPixelMap:
     """
     Assign each pixel in mask to the nearest seed, respecting boundaries.
@@ -249,8 +249,8 @@ def assign_regions(
         seeds_arr: ds.JitterSeedsArray = np.array(seeds, dtype=np.float32)
 
         jitter_x = jitter_y = None
-        if jagged:
-            jitter_x, jitter_y = _build_jitter_maps(h, w, seeds_arr)
+        if amplitude_factor != 0.0:
+            jitter_x, jitter_y = _build_jitter_maps(amplitude_factor, h, w, seeds_arr)
 
     with progress_controller.execute_phase(label_phase):
         labeled, num_components = ndlabel(mask)
@@ -481,7 +481,7 @@ def create_region_map(
         region_type: ds.RegionType, region_level: ds.RegionLevel,
         progress_controller: ProgressController,
         density: NDArray[Any] | None = None, density_strength: float = 1.0,
-        jagged: bool = False,
+        amplitude_factor=0.0,
     ) -> tuple[ds.RegionPixelMap, list[ds.RegionMetadata], int]:
     """
     Unified region map creator for both provinces and territories.
@@ -529,7 +529,7 @@ def create_region_map(
             )
 
     with progress_controller.execute_phase(assign_phase) as assign_progress:
-        pmap = assign_regions(fill_mask, seeds, start_index, assign_progress, jagged=jagged)
+        pmap = assign_regions(fill_mask, seeds, start_index, assign_progress, amplitude_factor=amplitude_factor)
 
     with progress_controller.execute_phase(borders_phase) as borders_progress:
         build_phase = borders_progress.add_phase(step_weight=100)

--- a/opengs_maptool/models/project.py
+++ b/opengs_maptool/models/project.py
@@ -45,8 +45,8 @@ class Project:
         self.land_territory_density = config.LAND_TERRITORIES_DEFAULT
         self.oceanic_territory_density = config.OCEAN_TERRITORIES_DEFAULT
         self.territory_density_strength = config.DENSITY_STRENGTH_DEFAULT
-        self.territory_jagged_land = False
-        self.territory_jagged_ocean = False
+        self.territory_jagged_land_amplitude = config.JAGGED_BORDER_LAND_AMPLITUDE_DEFAULT
+        self.territory_jagged_ocean_amplitude = config.JAGGED_BORDER_OCEAN_AMPLITUDE_DEFAULT
 
         self.territory_exclude_ocean = False
         self.province_exclude_ocean = False
@@ -54,8 +54,8 @@ class Project:
         self.land_province_density = config.LAND_PROVINCES_DEFAULT
         self.oceanic_province_density = config.OCEAN_PROVINCES_DEFAULT
         self.province_density_strength = config.DENSITY_STRENGTH_DEFAULT
-        self.province_jagged_land = False
-        self.province_jagged_ocean = False
+        self.province_jagged_land_amplitude = config.JAGGED_BORDER_LAND_AMPLITUDE_DEFAULT
+        self.province_jagged_ocean_amplitude = config.JAGGED_BORDER_OCEAN_AMPLITUDE_DEFAULT
 
         # Others
         self.file_path: str | None = None

--- a/opengs_maptool/ui/components/panels/left_panel.py
+++ b/opengs_maptool/ui/components/panels/left_panel.py
@@ -391,23 +391,33 @@ class LeftPanel(QWidget):
             display_scale=0.1
         )
 
-        # Territory jagged land checkbox
-        checkbox_territory_jagged_land = create_checkbox(
-            actions_layout, "Jagged Land Borders",
+        # Set territory jagged land Slider
+        slider_jagged_land_borders_strength = create_slider(
+            actions_layout,
+            "Jagged Land Borders Strength:",
+            config.JAGGED_BORDER_LAND_AMPLITUDE_MIN,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_MAX,
+            self._context.project.territory_jagged_land_amplitude,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_TICK,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_STEP,
             lambda value: setattr(self._context.project,
-                                  'territory_jagged_land', bool(value))
+                                  'territory_jagged_land_amplitude', value),
+            display_scale=0.01
         )
-        checkbox_territory_jagged_land.setChecked(
-            self._context.project.territory_jagged_land)
 
-        # Territory jagged ocean checkbox
-        checkbox_territory_jagged_ocean = create_checkbox(
-            actions_layout, "Jagged Ocean Borders",
+        # Set territory jagged Ocean Slider
+        slider_jagged_ocean_borders_strength = create_slider(
+            actions_layout,
+            "Jagged Ocean Borders Strength:",
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_MIN,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_MAX,
+            self._context.project.territory_jagged_ocean_amplitude,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_TICK,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_STEP,
             lambda value: setattr(self._context.project,
-                                  'territory_jagged_ocean', bool(value))
+                                  'territory_jagged_ocean_amplitude', value),
+            display_scale=0.01
         )
-        checkbox_territory_jagged_ocean.setChecked(
-            self._context.project.territory_jagged_ocean)
 
         # Generate territories button
         self.btn_generate_territories = create_button(
@@ -505,23 +515,33 @@ class LeftPanel(QWidget):
             display_scale=0.1
         )
 
-        # Province jagged land checkbox
-        checkbox_province_jagged_land = create_checkbox(
-            actions_layout, "Jagged Land Borders",
+        # Set province jagged land Slider
+        slider_jagged_land_borders_strength = create_slider(
+            actions_layout,
+            "Jagged Land Borders Strength:",
+            config.JAGGED_BORDER_LAND_AMPLITUDE_MIN,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_MAX,
+            self._context.project.province_jagged_land_amplitude,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_TICK,
+            config.JAGGED_BORDER_LAND_AMPLITUDE_STEP,
             lambda value: setattr(self._context.project,
-                                  'province_jagged_land', bool(value))
+                                  'province_jagged_land_amplitude', value),
+            display_scale=0.01
         )
-        checkbox_province_jagged_land.setChecked(
-            self._context.project.province_jagged_land)
 
-        # Province jagged ocean checkbox
-        checkbox_province_jagged_ocean = create_checkbox(
-            actions_layout, "Jagged Ocean Borders",
+        # Set province jagged Ocean Slider
+        slider_jagged_ocean_borders_strength = create_slider(
+            actions_layout,
+            "Jagged Ocean Borders Strength:",
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_MIN,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_MAX,
+            self._context.project.province_jagged_ocean_amplitude,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_TICK,
+            config.JAGGED_BORDER_OCEAN_AMPLITUDE_STEP,
             lambda value: setattr(self._context.project,
-                                  'province_jagged_ocean', bool(value))
+                                  'province_jagged_ocean_amplitude', value),
+            display_scale=0.01
         )
-        checkbox_province_jagged_ocean.setChecked(
-            self._context.project.province_jagged_ocean)
 
         # Generate provinces button
 


### PR DESCRIPTION
Replaces the jagged border checkboxes with two sliders (jagged_land_strength and jagged_ocean_strength) to control jagged border intensity for land and ocean territories independently.
<img width="357" height="229" alt="screenshot-2026-08-31_19-30-40" src="https://github.com/user-attachments/assets/bee3211b-d154-460c-a43a-ac6aa0d214c0" />
